### PR TITLE
chore(prlint): add prlint rules

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,0 +1,50 @@
+{
+  "title": [
+    {
+      "pattern": "^(chore|build|ci|docs|feat|fix|perf|refactor|style|test)(\\((?:\\w|['-]\\w){1,10}\\)):\\s",
+      "message": "Your title must be compliant with conventional commits!",
+      "detailsURL": "https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification"
+    }
+  ],
+  "body": [
+    {
+      "pattern": "(AC|MC|MTW|SRE|RE)-\\d{1,9}",
+      "flags": ["i"],
+      "message": "You need a JIRA ticket in your description",
+      "detailsURL": "https://agile.vignetcorp.com:8085/jira/secure/Dashboard.jspa"
+    },
+    {
+      "pattern": ".{1,}",
+      "message": "You need literally anything in your description",
+      "detailsURL": "https://github.com/VibrentHealth/redisson/blob/master/.github/prlint.json"
+    }
+  ],
+  "head.ref": [
+    {
+      "pattern": "^(feature|fix|release)/",
+      "message": "Your branch name is invalid, must be a feature, fix, or release",
+      "detailsURL": "https://github.com/VibrentHealth/redisson/blob/master/.github/prlint.json"
+    }
+  ],
+  "assignee.login": [
+    {
+      "pattern": ".+",
+      "message": "You need to assign someone",
+      "detailsURL": "https://github.com/VibrentHealth/redisson/blob/master/.github/prlint.json"
+    }
+  ],
+  "additions": [
+    {
+      "pattern": "0|^[1-9]$|^[1-9]$|^[1-9]\\d$",
+      "message": "Your PR is too big (over 999 additions)",
+      "detailsURL": "https://github.com/VibrentHealth/redisson/blob/master/.github/prlint.json"
+    }
+  ],
+  "labels.0.name": [
+    {
+      "pattern": ".{1,}",
+      "message": "Please add a label!",
+      "detailsURL": "https://github.com/VibrentHealth/redisson/blob/master/.github/prlint.json"
+    }
+  ]
+}

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed as stale.


### PR DESCRIPTION
Adding standardized ruleset for all repositories for stalebot and prlint bot.
        These rules can be extended or modified, but this is the standard.

  RE-82